### PR TITLE
Ternary operator to not trim undefined address or phone number

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,8 +98,8 @@ Showtimes.prototype.getTheaters = function (cb) {
       theaterData = {
         id: theaterId,
         name: theater.find('.desc h2.name').text(),
-        address: info[0].trim(),
-        phoneNumber: info[1].trim(),
+        address: info[0] ? info[0].trim() : "",
+        phoneNumber: info[1] ? info[1].trim() : "",
         movies: []
       };
 


### PR DESCRIPTION
Was seeing error when fetching zipcode: 75201

 TypeError: Cannot call method 'trim' of undefined